### PR TITLE
Allow lists as JSON root objects

### DIFF
--- a/django_jsonforms/forms.py
+++ b/django_jsonforms/forms.py
@@ -92,7 +92,7 @@ class JSONSchemaField(fields.CharField):
         return value
 
     def prepare_value(self, value):
-        if isinstance(value, dict):
+        if isinstance(value, (dict, list)):
             return json.dumps(value)
         return value
 


### PR DESCRIPTION
Change prepare_value of JSONSchemaField to allow lists as well as dicts as JSON root objects.